### PR TITLE
Added libnss support

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_suricata
+++ b/dalton-agent/Dockerfiles/Dockerfile_suricata
@@ -10,7 +10,7 @@ ARG ENABLE_RUST
 RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3.8 \
     tcpdump \
-    libpcre3 libpcre3-dbg libpcre3-dev \
+    libpcre3 libpcre3-dbg libpcre3-dev libnss3-dev\
     build-essential autoconf automake libtool libpcap-dev libnet1-dev \
     libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 \
     make libmagic-dev libjansson-dev libjansson4 pkg-config rustc cargo

--- a/dalton-agent/dalton-agent.py
+++ b/dalton-agent/dalton-agent.py
@@ -937,7 +937,7 @@ def run_suricata_sc():
 
     SCONTROL.connect()
     if SC_FIRST_RUN:
-        bug4225_versions = ["5.0.5", "6.0.1", "7.0.0-dev"]
+        bug4225_versions = ["5.0.5", "5.0.6", "6.0.1", "6.0.2", "7.0.0-dev"]
         if SENSOR_ENGINE_VERSION_ORIG in bug4225_versions:
             # Re: https://redmine.openinfosecfoundation.org/issues/4225
             # Certain Suricata versions will throw an error on the


### PR DESCRIPTION
Also dealing with Redmine issue 4225 still not being fixed for latest Suricata releases (v5.0.6 and v6.0.2)